### PR TITLE
Initial velocity offset

### DIFF
--- a/ModelMultiParticlePersistFX.cs
+++ b/ModelMultiParticlePersistFX.cs
@@ -81,7 +81,7 @@ public class ModelMultiParticlePersistFX : EffectBehaviour {
     // Setting, except it will sample the offset from a (normal) disk rather
     // than from a cube. Units (SI): m/s.
     [Persistent]
-    public float randomInitalVelocityMaxOffsetMaxRadius = 0.0f;
+    public float randomInitalVelocityOffsetMaxRadius = 0.0f;
   #endregion Persistent fields
     
     public FXCurve emission = new FXCurve("emission", 1f);
@@ -300,8 +300,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour {
                         // Uniformly scatter newly emitted particles along the emitter's trajectory in order to remove the dotted smoke effect.
                         pPos -= (hostPart.rb.velocity + Krakensbane.GetFrameVelocity()) * UnityEngine.Random.value * variableDeltaTime;
                       }
-                      if (randomInitalVelocityMaxOffsetMaxRadius != 0.0) {
-                        Vector2 diskPoint = UnityEngine.Random.insideUnitCircle * randomInitalVelocityMaxOffsetMaxRadius;
+                      if (randomInitalVelocityOffsetMaxRadius != 0.0) {
+                        Vector2 diskPoint = UnityEngine.Random.insideUnitCircle * randomInitalVelocityOffsetMaxRadius;
                         Vector3d offset;
                         if (pVel.x == 0.0 && pVel.y == 0.0) {
                           offset = new Vector3d(diskPoint.x, diskPoint.y, 0.0);


### PR DESCRIPTION
Implements #5.

``` csharp
// The initial velocity of the particles will be offset by a random amount
// lying in a disk perpendicular to the mean initial velocity whose radius
// is randomOffsetMaxRadius. This is similar to Unity's 'Random Velocity'
// Setting, except it will sample the offset from a (normal) disk rather
// than from a cube. Units (SI): m/s.
[Persistent]
public float randomInitalVelocityOffsetMaxRadius = 0.0f;
```

En ce qui concerne l'identificateur, "je n'ai fait celle-ci plus longue que parce que je n'ai pas eu le loisir de la faire plus courte".
Note that while the behaviour of `fixedEmissions` has changed slightly internally, its usage is the same to the end user—now correctly documented:

``` csharp
// Whether to nudge particles in order to alleviate the dotted smoke effect.
// Set this to true (default) when using 'Simulate World Space' in Unity,
// false otherwise.
[Persistent]
public bool fixedEmissions = true;
```
