### PR TITLE
Catch Exceptions tossed by GameObject.transform...

### DIFF
--- a/PersistentEmitterManager.cs
+++ b/PersistentEmitterManager.cs
@@ -66,19 +66,32 @@ internal class PersistentEmitterManager : MonoBehaviour
             // If the gameObject is null ( when ? I forgot ... )
             // or the tranform parent is null ( Emitter detached from part so the particle are not removed instantly )
             // then the emitter won't be updated by the effect FixedUpdate Call. So update it here
-            if (persistentEmittersCopy[i].go == null 
-                || persistentEmittersCopy[i].go.transform == null 
-                || persistentEmittersCopy[i].go.transform.parent == null)
+            if (persistentEmittersCopy[i].go == null)
             {
-                persistentEmittersCopy[i].EmitterOnUpdate(Vector3.zero);
-
-                if (persistentEmittersCopy[i].pe.pe.particles.Count() == 0)
+                Transform pecTransform = null;
+                
+                try
                 {
-                    EffectBehaviour.RemoveParticleEmitter(persistentEmittersCopy[i].pe);
-                    persistentEmitters.Remove(persistentEmittersCopy[i]);
-                    if (persistentEmittersCopy[i].go != null)
+                    pecTransform = persistentEmittersCopy[i].go.transform;
+                }
+                catch (NullReferenceException)
+                {
+                    // Destroy the gameobject so avoid exception handling in the future?
+                    continue;
+                }
+                
+                if (persistentEmittersCopy[i].go.transform.parent == null)
+                {
+                    persistentEmittersCopy[i].EmitterOnUpdate(Vector3.zero);
+
+                    if (persistentEmittersCopy[i].pe.pe.particles.Count() == 0)
                     {
-                        Destroy(persistentEmittersCopy[i].go);
+                        EffectBehaviour.RemoveParticleEmitter(persistentEmittersCopy[i].pe);
+                        persistentEmitters.Remove(persistentEmittersCopy[i]);
+                        if (persistentEmittersCopy[i].go != null)
+                        {
+                            Destroy(persistentEmittersCopy[i].go);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
 after parts have been removed by Unity.

The problem isn't in your code, it's in Unity.  Whatever's hidden behind Unity's wrapper in GameObject's transform getter is throwing the NRE; without knowing how that method is implemented it'd be a tall order to find an appropriate null gate to avoid the error.

This commit adds exception handling to the go.transform call and just skips it if there's a problem.  It might actually be more correct to destroy the GameObject, or remove the emitter from the List, or something like that; you'd know better than me. :)
