### PR TITLE
Add a few parameters for RealPlume

### DIFF
--- a/ModelMultiParticlePersistFX.cs
+++ b/ModelMultiParticlePersistFX.cs
@@ -56,6 +56,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
 
     [Persistent] public float fixedScale = 1;
 
+    [Persistent] public float emissionMult = 1;
+
     [Persistent] public float sizeClamp = 50;
 
     // Initial density of the particle seen as sphere of radius size of perfect
@@ -124,6 +126,10 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
     public MultiInputCurve initalVelocityOffsetMaxRadius;
 
     public MultiInputCurve randConeEmit;
+
+    public MultiInputCurve vRandPosOffset;
+
+    public MultiInputCurve vPosOffset;
 
     public MultiInputCurve xyForce;
 
@@ -334,7 +340,7 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         }
 
         inputs[(int)MultiInputCurve.Inputs.power] = power;
-        inputs[(int)MultiInputCurve.Inputs.density] = atmDensity;
+        inputs[(int)MultiInputCurve.Inputs.density] = (float)Math.Pow(atmDensity,SmokeScreenConfig.Instance.atmDensityExp);
         inputs[(int)MultiInputCurve.Inputs.mach] = surfaceVelMach;
         inputs[(int)MultiInputCurve.Inputs.parttemp] = partTemp;
         inputs[(int)MultiInputCurve.Inputs.externaltemp] = externalTemp;
@@ -361,7 +367,7 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
             pkpe.pe.minSize = Mathf.Min(pkpe.minSizeBase * sizePower, finalSizeClamp);
             pkpe.pe.maxSize = Mathf.Min(pkpe.maxSizeBase * sizePower, finalSizeClamp);
 
-            float emissionPower = emission.Value(inputs);
+            float emissionPower = emission.Value(inputs) * emissionMult;
             pkpe.pe.minEmission = Mathf.FloorToInt(pkpe.minEmissionBase * emissionPower);
             pkpe.pe.maxEmission = Mathf.FloorToInt(pkpe.maxEmissionBase * emissionPower);
 
@@ -389,6 +395,9 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
             pkpe.randConeEmit = randConeEmit.Value(inputs);
             pkpe.xyForce = xyForce.Value(inputs);
             pkpe.zForce = zForce.Value(inputs);
+
+            pkpe.vRandPosOffset = vRandPosOffset.Value(inputs);
+            pkpe.vPosOffset = vPosOffset.Value(inputs);
 
             pkpe.physical = physical && !SmokeScreenConfig.Instance.globalPhysicalDisable;
             pkpe.initialDensity = initialDensity;
@@ -636,6 +645,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         initalVelocityOffsetMaxRadius = new MultiInputCurve("initalVelocityOffsetMaxRadius", true);
         sizeClampCurve = new MultiInputCurve("sizeClamp", true);
         randConeEmit = new MultiInputCurve("randConeEmit", true);
+        vRandPosOffset = new MultiInputCurve("vRandPosOffset", true);
+        vPosOffset = new MultiInputCurve("vPosOffset", true);
         xyForce = new MultiInputCurve("xyForce", false);
         zForce = new MultiInputCurve("zForce", false);
 
@@ -657,6 +668,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         initalVelocityOffsetMaxRadius.Load(node);
         sizeClampCurve.Load(node);
         randConeEmit.Load(node);
+        vRandPosOffset.Load(node);
+        vPosOffset.Load(node);
         xyForce.Load(node);
         zForce.Load(node);
 
@@ -815,6 +828,24 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         else
         {
             Print("OnSave randConeEmit is null");
+        }
+
+        if (vRandPosOffset != null)
+        {
+            vRandPosOffset.Save(node);
+        }
+        else
+        {
+            Print("OnSave vRandPosOffset is null");
+        }
+
+        if (vPosOffset != null)
+        {
+            vPosOffset.Save(node);
+        }
+        else
+        {
+            Print("OnSave vPosOffset is null");
         }
 
         if (xyForce != null)
@@ -1026,6 +1057,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         min = Mathf.Min(min, initalVelocityOffsetMaxRadius.minInput[id]);
         min = Mathf.Min(min, sizeClampCurve.minInput[id]);
         min = Mathf.Min(min, randConeEmit.minInput[id]);
+        min = Mathf.Min(min, vRandPosOffset.minInput[id]);
+        min = Mathf.Min(min, vPosOffset.minInput[id]);
         min = Mathf.Min(min, xyForce.minInput[id]);
         min = Mathf.Min(min, zForce.minInput[id]);
 
@@ -1052,6 +1085,8 @@ public class ModelMultiParticlePersistFX : EffectBehaviour
         max = Mathf.Max(max, initalVelocityOffsetMaxRadius.maxInput[id]);
         max = Mathf.Max(max, sizeClampCurve.maxInput[id]);
         max = Mathf.Max(max, randConeEmit.minInput[id]);
+        max = Mathf.Max(max, vRandPosOffset.minInput[id]);
+        max = Mathf.Max(max, vPosOffset.minInput[id]);
         max = Mathf.Max(max, xyForce.minInput[id]);
         max = Mathf.Max(max, zForce.minInput[id]);
 

--- a/PersistentKSPParticleEmitter.cs
+++ b/PersistentKSPParticleEmitter.cs
@@ -234,13 +234,6 @@ public class PersistentKSPParticleEmitter
             
             if (particle.energy > 0)
             {
-<<<<<<< HEAD
-=======
-                Vector3d pPos = pe.useWorldSpace
-                    ? particle.position
-                    : peTransform.TransformPoint(particle.position);
->>>>>>> sarbian/master
-                
                 //Slight methodology change to avoid duplicating if statements:
                 Vector3d pVel;
                 Vector3d pPos;
@@ -275,7 +268,6 @@ public class PersistentKSPParticleEmitter
                     lVel = Vector3.Normalize(lVel);
                     lVel *= Vector3.Magnitude(particle.velocity);
 
-<<<<<<< HEAD
                     //Adjust initial position back along its position, if required.
                     //Apply a random offset if vRandOffset != 0, else apply zero.
                     float randoff = (vRandPosOffset != 0)? Random.Range(0, vRandPosOffset) : 0;
@@ -289,27 +281,15 @@ public class PersistentKSPParticleEmitter
                 else if (!pe.useWorldSpace && particle.energy != particle.startEnergy)
                 {
                     pPos = pe.transform.TransformPoint(particle.position);
-                    pVel = pe.transform.TransformDirection(particle.velocity.x * xyForce,
-=======
-                    pVel = peTransform.TransformDirection(lVel) + frameVel;
-                }
-                else if (!pe.useWorldSpace && particle.energy != particle.startEnergy)
-                {
                     pVel = peTransform.TransformDirection(particle.velocity.x * xyForce,
->>>>>>> sarbian/master
                                                            particle.velocity.y * xyForce,
                                                            particle.velocity.z * zForce)
                                 + frameVel;
                 }
                 else
                 {
-<<<<<<< HEAD
                     pPos = pe.transform.TransformPoint(particle.position);
-                    pVel = pe.transform.TransformDirection(particle.velocity)
-                                + Krakensbane.GetFrameVelocity();
-=======
                     pVel = peTransform.TransformDirection(particle.velocity) + frameVel;
->>>>>>> sarbian/master
                 }
                 
                 // try-finally block to ensure we set the particle velocities correctly in the end.

--- a/PersistentKSPParticleEmitter.cs
+++ b/PersistentKSPParticleEmitter.cs
@@ -75,6 +75,8 @@ public class PersistentKSPParticleEmitter
 
     public float sizeClamp = 50;
 
+    public bool clampXYstart = false;
+
     // The initial velocity of the particles will be offset by a random amount
     // lying in a disk perpendicular to the mean initial velocity whose radius
     // is randomOffsetMaxRadius. This is similar to Unity's 'Random Velocity'
@@ -84,6 +86,12 @@ public class PersistentKSPParticleEmitter
 
     //Similar to randomInitalVelocityOffsetMaxRadius, cleaned a little 
     public float randConeEmit = 0.0f;
+
+    //Additive random position offset
+    public float vRandPosOffset = 0.0f;
+
+    //Additive non-random position offset
+    public float vPosOffset = 0.0f;
 
     //xyForce multiplicatively damps non-axis (x,y) motion, leaving axis 
     //motion (z) untouched.
@@ -194,8 +202,9 @@ public class PersistentKSPParticleEmitter
         
         //For randConeEmit:
         //Only generate a random vector on every other particle, for the in-between particles, negate the disk.
-        bool coneToggle = true;
+        bool toggle = true;
         Vector2 disk = new Vector2 (0,0);
+        //For startSpread
 
         //Step through all the particles:
         for (int j = 0; j < particles.Length; j++)
@@ -217,44 +226,54 @@ public class PersistentKSPParticleEmitter
 
             if (particle.energy > 0)
             {
-                Vector3d pPos = pe.useWorldSpace
-                    ? particle.position
-                    : pe.transform.TransformPoint(particle.position);
                 
                 //Slight methodology change to avoid duplicating if statements:
                 Vector3d pVel;
+                Vector3d pPos;
                 if (pe.useWorldSpace)
                 {
                     pVel = particle.velocity;
+                    pPos = particle.position;
                 }
-                else if (!pe.useWorldSpace && particle.energy == particle.startEnergy && (randConeEmit != 0))
+                else if (!pe.useWorldSpace && particle.energy == particle.startEnergy)
                 {
-                    Vector3 lVel = new Vector3(0, 0, 1); ;
+                    Vector3 lVel = new Vector3(0, 0, 1);
+                    Vector3 lPos = particle.position;
+
                     // Adjust initial velocity to make a cone.  Only perform if pe.useWorldSpace
                     // is true, and we have a randConeEmit set.
                     //Produce a random vector within "angle" of the original vector.
                     //The maximum producible cone is 90 degrees when randConeEmit is very large.
                     //Could open up more if we used trig, but it'd be less efficient.
-                    if (coneToggle)
+
+                    if (toggle)
                     {
                         disk = Random.insideUnitCircle * randConeEmit;
-                        coneToggle = false;
+                        toggle = false;
                     }
                     else
                     {
                         disk *= -1;
-                        coneToggle = true;
+                        toggle = true;
                     }
                     lVel.x = disk.x;
                     lVel.y = disk.y;
                     lVel = Vector3.Normalize(lVel);
                     lVel *= Vector3.Magnitude(particle.velocity);
 
+                    //Adjust initial position back along its position, if required.
+                    //Apply a random offset if vRandOffset != 0, else apply zero.
+                    float randoff = (vRandPosOffset != 0)? Random.Range(0, vRandPosOffset) : 0;
+                    lPos += Vector3.Normalize(lVel) * (randoff + vPosOffset);
+
+                    //Finalize position and velocity
+                    pPos = pe.transform.TransformPoint(lPos);
                     pVel = pe.transform.TransformDirection(lVel)
                                 + Krakensbane.GetFrameVelocity();
                 }
                 else if (!pe.useWorldSpace && particle.energy != particle.startEnergy)
                 {
+                    pPos = pe.transform.TransformPoint(particle.position);
                     pVel = pe.transform.TransformDirection(particle.velocity.x * xyForce,
                                                            particle.velocity.y * xyForce,
                                                            particle.velocity.z * zForce)
@@ -262,6 +281,7 @@ public class PersistentKSPParticleEmitter
                 }
                 else
                 {
+                    pPos = pe.transform.TransformPoint(particle.position);
                     pVel = pe.transform.TransformDirection(particle.velocity)
                                 + Krakensbane.GetFrameVelocity();
                 }

--- a/SmokeScreenConfig.cs
+++ b/SmokeScreenConfig.cs
@@ -36,6 +36,8 @@ namespace SmokeScreen
     {
         [Persistent] public int maximumActiveParticles = 8000; // The engine won't spawn more than 10k anyway
 
+        [Persistent] public float atmDensityExp = 1; //Atmospheric multiplier for scaling growth.  Intended as a global RealPlume parameter.
+
         [Persistent] public bool globalCollideDisable = false;
 
         [Persistent] public bool globalPhysicalDisable = false;


### PR DESCRIPTION
Global SmokeScreen Parameter:
atmDensityExp - SmokeScreen.cfg variable, adjusts input atmospheric
pressure by an exponent, to give similar plume scaling between RSS and
Stock.

ModelMultiParticlePersistFX Parameters:
vRandPosOffset - Random positive position offset to spread fast
particles out.  Additive.
vPosOffset - nonrandom positive offset to adjust starting particle
position.  Additive.
emissionMult - emission multiplier.  Intended for use on multiple-thrustTransform engines to reduce particle count overall.