### PR TITLE
Add an option to emit particles on 'LateUpdate'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 *.sdf
 *.opensdf
 *.unsuccessfulbuild
+.vs/
 ipch/
 [Oo]bj/
 [Bb]in

--- a/ModelMultiShurikenPersistFX.cs
+++ b/ModelMultiShurikenPersistFX.cs
@@ -91,14 +91,26 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
     // TODO Sarbian : have the init auto fill this one
     [Persistent] public float randomInitalVelocityOffsetMaxRadius = 0.0f;
 
-	// Enables particle decluttering
+	// Enables particle declustering
 	// This adds a vector to particle's position based on velocity, deltaTime, and which particle of the frame is it.
 	// ⁙    ⁙    ⁙    ⁙    ⁙    ⁙    ⁙
 	// ^      false
 	// SPAWNED IN ONE FRAME
 	// vvvvv  true
 	// ···································
-	[Persistent] public bool declutter = false;
+	[Persistent] public bool decluster = false;
+
+    // Emits particles on LateUpdate, rather than FixedUpdate, if enabled
+    //
+    // Synchronizes particle emission with frame draws. That fixes the 'sliding away from origin' on lower FPS
+    // (I think new particles effectively skip first physics pass before drawing)
+    // Check here (Rightmost one is enabled): https://i.imgur.com/fTU2F7r.gif
+    // 
+    // Also, makes decluster more consistent. Frame draws are not synchronized with FixedUpdate.
+    // Decluster relies on Time.deltaTime to calculate distance to last emmited particle.
+    // On FixedUpdate, the Time.deltaTime is always 0.02, regardless of how much time actually passed from last frame draw.
+    // On LateUpdate,  the Time.deltaTime is the actual time from last draw, so decluster can predict last particle's position a lot better
+    [Persistent] public bool emitOnUpdate = false;
 
     [Persistent]
     public int particleCountLimit = 1000;
@@ -168,6 +180,11 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
             return lastMaxActiveParticles;
         }
     }
+
+    // Previous way of counting particle count relied on the particled being emitted/updated synchronously with each other.
+    // With 'emitOnUpdate' changes, particles can be updated either in FixedUpdate, or LateUpdate.
+    // Used to count all currently active particles, and to display current particle count of this effect in SmokeScreen UI.
+    public int CurrentlyActiveParticles => persistentEmitters.Sum (x => x.pe.particleCount);
 
     public string node_backup = string.Empty;
 
@@ -355,11 +372,13 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
         //        Debug.Log(vHit2.collider.name);
         //}
 
-        for (int i = 0; i < persistentEmitters.Count; i++)
-        {
-            PersistentKSPShurikenEmitter persistentKspShurikenEmitter = persistentEmitters[i];
-            persistentKspShurikenEmitter.EmitterOnUpdate(hostPart.Rigidbody.velocity + Krakensbane.GetFrameVelocity());
-        }
+        foreach (PersistentKSPShurikenEmitter emitter in persistentEmitters) {
+			// This is FixedUpdate, so don't emit here if particles should emit in LateUpdate
+			if (!emitOnUpdate) {
+				emitter.EmitterOnUpdate (hostPart.Rigidbody.velocity + Krakensbane.GetFrameVelocity ());
+			}
+		}
+
     }
 
     private void UpdateInputs(float power)
@@ -477,7 +496,7 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
             pkpe.logarithmicGrow = logGrow.Value(inputs);
             pkpe.logarithmicGrowScale = logGrowScale.Value(inputs);
 
-			pkpe.declutter = declutter;
+			pkpe.decluster = decluster;
 
             pkpe.linearGrow = linGrow.Value(inputs);
 
@@ -547,6 +566,27 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
 
             persistentEmitters[i].pr.maxParticleSize = persistentEmitters[i].maxSizeBase * angle.Value(currentAngle) * distance.Value(currentDist);
         }
+    }
+
+    // First, I tried to emit particles on regular Update, but stuff was weird, and the plume still appeared out of sync with frame draws
+    // According to https://docs.unity3d.com/Manual/ExecutionOrder.html
+    // LateUpdate is the last thing that happens before frame draw. That makes it as synced to frame draws, as possible
+    // LateUpdate is called after physics calculations too, so the newly emitted plume particles are right where they should be.
+    public void LateUpdate () {
+		foreach (PersistentKSPShurikenEmitter emitter in persistentEmitters) {
+			if (emitter.go is null) {
+				continue;
+			}
+
+			if (emitOnUpdate) {
+				emitter.EmitterOnUpdate (hostPart.Rigidbody.velocity + Krakensbane.GetFrameVelocity ());
+			}
+		}
+
+        // I think it's important to call this even though it doesn't count active particles
+        // because it calculates how many particles should be removed on next emit pass.
+        SmokeScreenConfig.UpdateParticlesCount ();
+
     }
 
     public override void OnInitialize()

--- a/SmokeScreenConfig.cs
+++ b/SmokeScreenConfig.cs
@@ -67,18 +67,22 @@ namespace SmokeScreen
 
         public static void UpdateParticlesCount()
         {
+            // Like stated before, because emission passes can be out of sync now, activeParticles is not a reliable
+            // way to measure how many particles are out there.
+            int currentlyActiveParticles = 0;
+            ModelMultiShurikenPersistFX.List.ForEach (x => currentlyActiveParticles += x.CurrentlyActiveParticles);
             if (lastTime < Time.fixedTime)
             {
-                if (activeParticles > Instance.maximumActiveParticles)
+                if (currentlyActiveParticles > Instance.maximumActiveParticles)
                 {
-                    int toRemove = activeParticles - Instance.maximumActiveParticles;
+                    int toRemove = currentlyActiveParticles - Instance.maximumActiveParticles;
                     if (toRemove < Instance.maximumActiveParticles)
                     {
-                        particleDecimate = activeParticles / (toRemove + 1); // positive we remove each n
+                        particleDecimate = currentlyActiveParticles / (toRemove + 1); // positive we remove each n
                     }
                     else
                     {
-                        particleDecimate = -activeParticles / Instance.maximumActiveParticles;
+                        particleDecimate = -currentlyActiveParticles / Instance.maximumActiveParticles;
 
                         // negative we keep each n
                     }

--- a/SmokeScreenUI.cs
+++ b/SmokeScreenUI.cs
@@ -98,19 +98,24 @@ namespace SmokeScreen
                 out SmokeScreenConfig.Instance.maximumActiveParticles);
             GUILayout.EndHorizontal();
 
-            GUILayout.Label("activeParticles : " + SmokeScreenConfig.activeParticles);
+            // 'SmokeScreenConfig.activeParticles' isn't accurate anymore
+            int activeParticles = 0;
+            ModelMultiShurikenPersistFX.List.ForEach (x => activeParticles += x.CurrentlyActiveParticles);
+            GUILayout.Label ($"Active particles: {activeParticles}");
 
             GUILayout.Space(10);
 
             GUILayout.Label("Open ModelMultiShurikenPersistFX UI :");
-
+            
             foreach (var mmFX in ModelMultiShurikenPersistFX.List)
             {
                 if (mmFX.hostPart != null)
                 {
+                    // Changed to string interpolation, and added current particle count alongside max particle count per plume
                     mmFX.showUI = GUILayout.Toggle(
                         mmFX.showUI,
-                        mmFX.hostPart.name + " " + mmFX.effectName + " " + mmFX.instanceName + "(" + mmFX.MaxActiveParticles + ")");
+                        $"{mmFX.hostPart.name}: {mmFX.effectName}, {mmFX.instanceName}: {mmFX.CurrentlyActiveParticles} ({mmFX.MaxActiveParticles} max)"
+                    );
                 }
             }
 


### PR DESCRIPTION
There might be some garbage in diff, because I didn't notice my VS was configured to use tabs. Sorry.

Every major change should be commented.
### Changes overview:
* Particles can now emit on FixedUpdate or LateUpdate, depending on `emitOnUpdate` option. Disabled by default.
* Some code had to be adapted to work with both LateUpdate and FixedUpdate.
* Previous active particle count method didn't work, because particle emission passes were not synchronized. Changed the way active particles are counted.
* Tweaked plume list text in UI. Now shows current particle count as well.
* Changed `declutter` to `decluster`. I believe it better represents what it does.

### Other pics:
In no particular order

***

Tweaked UI. Now you can view current particle count per-plume
![](https://imgur.com/VHJ7Ie7.png)

***

Contrary to what the code said, the collisions work just fine in either Update.
![](https://imgur.com/GJWEBiD.png)

***

I didn't notice any performance drop caused by either the previous, or this pull request.
![](https://imgur.com/CG1jqAG.png)

***

High velocity plumes are now possible. The segmenting in leftmost plume's gradient is because the particles were emitted in batches. This could be fixed by pre-removing remaining life from emitted particles (Something to look into in the future)
![](https://imgur.com/0XAVUdU.png)

***

Low FPS default, and `decluster` + `emitOnUpdate` comparison
![](https://imgur.com/uv0527J.png)

***

`decluster` and `decluster` + `emitOnUpdate` comparison. Notice, how the plume separates from the leftmost plume.
![](https://imgur.com/uoNMel6.png)

***

Default, `decluster` and `decluster` + `emitOnUpdate` side to side comparison. Notice, how the rightmost plume doesn't react to FPS changes.
[GIF too large. Click here](https://imgur.com/FVAsoPO.gif)

***

Default and `decluster` + `emitOnUpdate` comparison in RealPlume. The only change in configs between these two, is adding the snippet below to plume on the right. The FPS was around 20 (The usual FPS of a standard RO install :P)
```
decluster = true
emitOnUpdate = true
```
![](https://imgur.com/10XrAkK.png)