### PR TITLE
Add partTransform support and manual input sharing

### DIFF
--- a/ModelMultiShurikenPersistFX.cs
+++ b/ModelMultiShurikenPersistFX.cs
@@ -402,6 +402,13 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
     {
         if (overRideInputs)
         {
+            if (SmokeScreenConfig.Instance.shareManualInput)
+            {
+                for (int i = 0; i < MultiInputCurve.inputsCount; i++)
+                {
+                    inputs[i] = SmokeScreenConfig.Instance.sharedInputs[i];
+                }
+            }
             return;
         }
 
@@ -617,8 +624,15 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
         List<Transform> transforms = new List<Transform>(hostPart.FindModelTransforms(transformName));
         if (transforms.Count == 0)
         {
-            Print("Cannot find transform " + transformName);
-            return;
+            if (transformName == "partTransform")
+            {
+                transforms.Add(hostPart.partTransform);
+            }
+            else
+            {
+                Print("Cannot find transform " + transformName);
+                return;
+            }
         }
         GameObject model = GameDatabase.Instance.GetModel(modelName);
         if (model == null)
@@ -1242,6 +1256,8 @@ public class ModelMultiShurikenPersistFX : EffectBehaviour
                     maxInput(id),
                     GUILayout.ExpandWidth(true));
             }
+
+            SmokeScreenConfig.Instance.sharedInputs[id] = inputs[id];
 
             GUILayout.EndHorizontal();
         }

--- a/SmokeScreenConfig.cs
+++ b/SmokeScreenConfig.cs
@@ -46,6 +46,10 @@ namespace SmokeScreen
 
         [Persistent] public bool forceDecluster = false;
 
+        [Persistent] public bool shareManualInput = false;
+
+        public readonly float[] sharedInputs = new float[MultiInputCurve.inputsCount];
+
         public static int activeParticles = 0;
 
         public static int particleDecimate = 0;

--- a/SmokeScreenUI.cs
+++ b/SmokeScreenUI.cs
@@ -92,6 +92,9 @@ namespace SmokeScreen
             SmokeScreenConfig.Instance.forceDecluster =
                 GUILayout.Toggle(SmokeScreenConfig.Instance.forceDecluster, "Globally force decluster");
 
+            SmokeScreenConfig.Instance.shareManualInput =
+                GUILayout.Toggle(SmokeScreenConfig.Instance.shareManualInput, "Share manual input values across effects");
+
             GUILayout.Space(10);
 
             GUILayout.BeginHorizontal();


### PR DESCRIPTION
This PR adds two new features.

First, "partTransform" can now be given as the transformName in a plume config to position an effect relative to the host part instead of relying on a child transform (typically "thrustTransform").  The use case for this feature is engine models with multiple nozzles, e.g., the RAPIER where thrustTransform gives a set of 4 transforms.  There are cases where the plume designer wants only one emitter for a particular plume element.  Here's an example use of partTransform for the bypass ramjets on the ReStock RAPIER model:
![ring_q99](https://user-images.githubusercontent.com/11653155/78187836-2c1ac380-743d-11ea-862b-439bdc9500d3.jpg)
For more on the new RAPIER plume, see https://forum.kerbalspaceprogram.com/index.php?/topic/188033-ksp191-realplume-stock-v310-15mar20/page/12/&tab=comments#comment-3764248

Second, a "Share manual input values across effects" toggle is added to the main GUI window.  Enabling this makes all effects that currently have "Manual Inputs" enabled use the settings from the active effect window.  The motivation for this feature is that over time, plumes have grown more complex than how they used to be.  Some recent generics have more than 10 elements.  When configuring/editing/creating such plumes, it's very helpful to make sure they are changing in sync with each other.  E.g., a shock cone composed of a leading diamond and trailing shock wake using different particles that need to fade in unison as altitude increases.